### PR TITLE
scram: fix handling of bytes responses, add support for sha512 digests

### DIFF
--- a/sasl-doc/sasl.scrbl
+++ b/sasl-doc/sasl.scrbl
@@ -129,9 +129,11 @@ on their arguments when appropriate.
 This module implements the @hyperlink["https://tools.ietf.org/html/rfc5802"]{@tt{SCRAM}}
 family of authentication mechanisms, namely
 @as-index{@hyperlink["https://tools.ietf.org/html/rfc5802"]{@tt{SCRAM-SHA-1}
-and @tt{SCRAM-SHA-1-PLUS}}} and
+and @tt{SCRAM-SHA-1-PLUS}}},
 @as-index{@hyperlink["https://tools.ietf.org/html/rfc7677"]{@tt{SCRAM-SHA-256}
-and @tt{SCRAM-SHA-256-PLUS}}}.
+and @tt{SCRAM-SHA-256-PLUS}}} and
+@as-index{@hyperlink["https://datatracker.ietf.org/doc/html/draft-melnikov-scram-sha-512-02"]{@tt{SCRAM-SHA-512}
+and @tt{SCRAM-SHA-512-PLUS}}}.
 
 The @tt{SCRAM} protocol family has the following structure:
 @itemlist[#:style 'ordered
@@ -144,7 +146,7 @@ In particular: the client sends the first message; authentication success or
 failure is conveyed at in SASL protocol layer; and the server authenticates
 itself to the client. Messages are represented as strings.
 
-@defproc[(make-scram-client-ctx [digest (or/c 'sha1 'sha256)]
+@defproc[(make-scram-client-ctx [digest (or/c 'sha1 'sha256 'sha512)]
                                 [authentication-id string?]
                                 [password string?]
                                 [#:authorization-id authorization-id (or/c string? #f) #f]
@@ -153,10 +155,11 @@ itself to the client. Messages are represented as strings.
                                                    #f])
          sasl-ctx?]{
 
-Creates a @tt{SCRAM} protocol context. The @racket[digest] argument selects
-between @tt{SCRAM-SHA-1} and @tt{SCRAM-SHA-256}. The @racket[authentication-id],
-@racket[password], and (if provided) @racket[authorization-id] arguments are
-automatically processed using @racket[saslprep].
+Creates a @tt{SCRAM} protocol context. The @racket[digest] argument
+selects between @tt{SCRAM-SHA-1}, @tt{SCRAM-SHA-256} and
+@tt{SCRAM-SHA-512}, respectively. The @racket[authentication-id],
+@racket[password], and (if provided) @racket[authorization-id]
+arguments are automatically processed using @racket[saslprep].
 
 The @racket[channel-binding] argument must have the form @racket[(list
 _cb-type _cb-data)] if the server offered and the client selected a
@@ -173,8 +176,12 @@ not offer a @tt{PLUS} option. The @racket[channel-binding] argument
 should be @racket[#f] if the client does not support channel binding
 (for example, if the channel is not a TLS connection).
 
-@history[#:changed "1.1" @elem{Added the @racket[#:channel-binding]
-argument and support for @tt{PLUS} mechanism variants.}]}
+@history[
+  #:changed "1.1" @elem{Added the @racket[#:channel-binding]
+  argument and support for @tt{PLUS} mechanism variants.}
+
+  #:changed "1.2" @elem{Added support for the @racket['sha512]
+  digest.}]}
 
 @; ----------------------------------------
 @section[#:tag "sasl-cram-md5"]{@tt{CRAM-MD5} Authentication}

--- a/sasl-lib/info.rkt
+++ b/sasl-lib/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 
-(define version "1.1")
+(define version "1.2")
 (define collection "sasl")
 (define deps '(["base" #:version "6.10"]))
 

--- a/sasl-lib/private/crypto.rkt
+++ b/sasl-lib/private/crypto.rkt
@@ -17,6 +17,7 @@
 (define-libcrypto EVP_md5    (_fun -> _EVP_MD))
 (define-libcrypto EVP_sha1   (_fun -> _EVP_MD))
 (define-libcrypto EVP_sha256 (_fun -> _EVP_MD))
+(define-libcrypto EVP_sha512 (_fun -> _EVP_MD))
 
 ;; In libcrypto 1.1, EVP_MD_CTX_{create,destroy} renamed to {new,free}.
 (define-libcrypto EVP_MD_CTX_new (_fun -> _EVP_MD_CTX))
@@ -94,6 +95,7 @@
     [(md5) (EVP_md5)]
     [(sha1) (EVP_sha1)]
     [(sha256) (EVP_sha256)]
+    [(sha512) (EVP_sha512)]
     [else (error who "unsupported digest\n  digest: ~e" digest)]))
 
 (define (bytes-xor bs1 bs2)

--- a/sasl-lib/private/scram.rkt
+++ b/sasl-lib/private/scram.rkt
@@ -68,7 +68,7 @@
 ;; 2: S->C
 ;; 3: C->S
 
-;; scram-client-receive-1 : Ctx String -> Void
+;; scram-client-receive-1 : Ctx Bytes|String -> Void
 (define (scram-client-receive-1 ctx msg-s1)
   (define msg-s1-str (->string msg-s1))
   (match-define (scram-client-ctx _ _ h) ctx)

--- a/sasl-lib/scram.rkt
+++ b/sasl-lib/scram.rkt
@@ -4,7 +4,7 @@
          "private/scram.rkt")
 (provide (contract-out
           [make-scram-client-ctx
-           (->* [(or/c 'sha1 'sha256)
+           (->* [(or/c 'sha1 'sha256 'sha512)
                  string?
                  string?]
                 [#:authorization-id (or/c #f string?)


### PR DESCRIPTION
`SCRAM-SHA-512` [isn't standardized](https://datatracker.ietf.org/doc/draft-melnikov-scram-sha-512/), but it is used in the wild (eg. in [Apache Kafka](https://docs.confluent.io/platform/current/kafka/authentication_sasl/authentication_sasl_scram.html#configuring-scram)). 
I don't think there's much downside to allowing the extra digest. 

The string change is a fix to make scram correctly support `sasl-receive-message`'s contract, which is `(or/c bytes? string?)`, whereas before this change it would fail if given a `bytes?` message.