### PR TITLE
ffi: add fallbacks for OpenSSL 3.0 variants of EVP_MD_{block_,}size

### DIFF
--- a/sasl-lib/private/crypto.rkt
+++ b/sasl-lib/private/crypto.rkt
@@ -11,8 +11,16 @@
 (define-cpointer-type _EVP_MD)
 (define-cpointer-type _EVP_MD_CTX)
 
-(define-libcrypto EVP_MD_size (_fun _EVP_MD -> _int))
-(define-libcrypto EVP_MD_block_size (_fun _EVP_MD -> _int))
+(define-libcrypto EVP_MD_size (_fun _EVP_MD -> _int)
+  #:make-fail (lambda (name)
+                (lambda ()
+                  (get-ffi-obj 'EVP_MD_get_size libcrypto (_fun _EVP_MD -> _int)
+                               (make-not-available name)))))
+(define-libcrypto EVP_MD_block_size (_fun _EVP_MD -> _int)
+  #:make-fail (lambda (name)
+                (lambda ()
+                  (get-ffi-obj 'EVP_MD_get_block_size libcrypto (_fun _EVP_MD -> _int)
+                               (make-not-available name)))))
 
 (define-libcrypto EVP_md5    (_fun -> _EVP_MD))
 (define-libcrypto EVP_sha1   (_fun -> _EVP_MD))

--- a/sasl-lib/private/crypto.rkt
+++ b/sasl-lib/private/crypto.rkt
@@ -16,11 +16,6 @@
                 (lambda ()
                   (get-ffi-obj 'EVP_MD_get_size libcrypto (_fun _EVP_MD -> _int)
                                (make-not-available name)))))
-(define-libcrypto EVP_MD_block_size (_fun _EVP_MD -> _int)
-  #:make-fail (lambda (name)
-                (lambda ()
-                  (get-ffi-obj 'EVP_MD_get_block_size libcrypto (_fun _EVP_MD -> _int)
-                               (make-not-available name)))))
 
 (define-libcrypto EVP_md5    (_fun -> _EVP_MD))
 (define-libcrypto EVP_sha1   (_fun -> _EVP_MD))


### PR DESCRIPTION
I noticed this issue while trying to use `db-lib` with Postgres on a Ubuntu 22.04 VM. It looks like a similar fix has already been applied to the `openssl` lib in Racket.

See also: https://www.openssl.org/docs/man3.0/man3/EVP_MD_size.html#HISTORY